### PR TITLE
Fixes unsupported syntax for `changed` test.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 - name: Update package lists
   apt:
     update_cache: True
-  when: (wine__register_arch_enabled|changed)
+  when: (wine__register_arch_enabled is changed)
   tags: [ 'role::wine:pkgs' ]
 
 - name: Ensure specified packages are in there desired state


### PR DESCRIPTION
Using the changed test as a filter "| changed" generates an error when using Ansible 2.9. I updated the syntax to "is changed".